### PR TITLE
Set adequate keystore path

### DIFF
--- a/src/auth/sgadmin.sh
+++ b/src/auth/sgadmin.sh
@@ -3,7 +3,7 @@
 chmod +x /usr/share/elasticsearch/plugins/search-guard-5/tools/sgadmin.sh
 plugins/search-guard-5/tools/sgadmin.sh \
 -cd /usr/share/elasticsearch/config/searchguard \
--ks /usr/share/elasticsearch/config/searchguard/ssl/elastic-keystore.jks \
+-ks /usr/share/elasticsearch/config/searchguard/ssl/${CLUSTER_NAME}-keystore.jks \
 -ts /usr/share/elasticsearch/config/searchguard/ssl/truststore.jks \
 -cn $CLUSTER_NAME \
 -kspass $KS_PWD \


### PR DESCRIPTION
Not sure about this one, but regarding the keystore path in https://github.com/Khezen/docker-elasticsearch/blob/master/config/elasticsearch.yml#L26 it looks like wrong here.