### PR TITLE
remove extra && from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH /elasticsearch/bin:$PATH
 # Install Elasticsearch.
 RUN apk add --no-cache --update bash ca-certificates su-exec util-linux curl openssl rsync
 RUN apk add --no-cache -t .build-deps gnupg \
-  && mkdir /install && \
+  && mkdir /install \
   && cd /install \
   && echo "===> Install Elasticsearch..." \
   && curl -o elasticsearch.tar.gz -Lskj "$ES_TARBAL"; \


### PR DESCRIPTION
Fixing the error on docker build .
Step 13/23 : RUN apk add --no-cache -t .build-deps gnupg   && mkdir /install &&   && cd /install   && echo "===> Install Elasticsearch..."   && curl -o elasticsearch.tar.gz -Lskj "$ES_TARBAL";   if [ "$ES_TARBALL_ASC" ]; then     curl -o elasticsearch.tar.gz.asc -Lskj "$ES_TARBALL_ASC";     export GNUPGHOME="$(mktemp -d)";     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY";     gpg --batch --verify elasticsearch.tar.gz.asc elasticsearch.tar.gz;     rm -r "$GNUPGHOME" elasticsearch.tar.gz.asc;   fi;   tar -xf elasticsearch.tar.gz   && ls -lah   && mv elasticsearch-$ES_VERSION /elasticsearch   && adduser -DH -s /sbin/nologin elasticsearch   && echo "===> Installing search-guard..."   && /elasticsearch/bin/elasticsearch-plugin install -b "com.floragunn:search-guard-6:$ES_VERSION-$SG_VERSION"   && echo "===> Creating Elasticsearch Paths..."   && for path in    /elasticsearch/config       /elasticsearch/config/scripts       /elasticsearch/plugins   ; do   mkdir -p "$path";   chown -R elasticsearch:elasticsearch "$path";   done   && rm -rf /install   && rm /elasticsearch/config/elasticsearch.yml   && apk del --purge .build-deps
 ---> Running in c9185fca4148
/bin/sh: syntax error: unexpected "&&"