### PR TITLE
Enable 'admin' role REST management API + configuration GUI

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -19,6 +19,9 @@ http:
     allow-origin: ${HTTP_CORS_ALLOW_ORIGIN}
 
 searchguard:
+    restapi:
+        roles_enabled:
+          - "admin"
     ssl.transport:
         enabled: true
         enable_openssl_if_available: true


### PR DESCRIPTION
Adding the configuration `searchguard.restapi.roles_enabled` for `admin` role.  This enables both the REST management API and the Search Guard configuration GUI.

This resolves #18.