### PR TITLE
Fix unconsistent bash test

### DIFF
--- a/src/miscellaneous/index_level_settings.sh
+++ b/src/miscellaneous/index_level_settings.sh
@@ -2,7 +2,7 @@
 
 index_level_settings(){
   http="http"
-  if [ $HTTP_SSL ]; then
+  if [ "$HTTP_SSL" = "true" ]; then
     http="https"
   fi
 


### PR DESCRIPTION
**Describe the bug**
I may be wrong, but the test at https://github.com/khezen/docker-elasticsearch/blob/69658cfb973ed8235f3ede9ca5d344889f713d03/src/miscellaneous/index_level_settings.sh#L5 only check if `$HTTP_SSL` is defined or not. If `$HTTP_SSL ` equals `false` or ''false'`, it's still considered as true.

**Expected behavior**
Setting `HTTP_SSL=false` should make the call over http, not https.

That would be great if the fix could be merged back in all others branches included unsopported 5.5, 5.6.

Thanks